### PR TITLE
Delete empty parent directories which are above the initial target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2.0 - 2024-08-21
+
+Delete empty parent directories.
+
+If the target directory is the only entry in an otherwise empty directory, then the parent directory will also be deleted (and emptydir will keep going through parent directories until it finds one which is non-empty).
+
 ## v1.1.3 - 2024-08-21
 
 Delete empty folders which only contain a `.jekyll-cache` folder.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "emptydir"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emptydir"
-version = "1.1.3"
+version = "1.2.0"
 edition = "2021"
 
 [dependencies]

--- a/src/emptydir.rs
+++ b/src/emptydir.rs
@@ -47,7 +47,7 @@ mod test_emptydir {
         fs::create_dir_all(dir).unwrap();
     }
 
-    fn create_file(path: PathBuf) {
+    fn create_file(path: &PathBuf) {
         create_dir(&path.parent().unwrap().to_path_buf());
         fs::write(&path, "this file is for testing").unwrap();
     }
@@ -82,7 +82,7 @@ mod test_emptydir {
         // Create the directory, then add a text file
         create_dir(&dir);
 
-        create_file(dir.join("greeting.txt"));
+        create_file(&dir.join("greeting.txt"));
 
         assert_eq!(emptydir(&dir), 0);
         assert_eq!(dir.exists(), true);
@@ -109,15 +109,15 @@ mod test_emptydir {
         create_dir(&dir);
 
         create_dir(&dir.join(".venv"));
-        create_file(dir.join(".venv/bin/mypython.py"));
+        create_file(&dir.join(".venv/bin/mypython.py"));
 
         create_dir(&dir.join(".ipynb_checkpoints"));
-        create_file(dir.join(".ipynb_checkpoints/analysis-checkpoint.ipynb"));
+        create_file(&dir.join(".ipynb_checkpoints/analysis-checkpoint.ipynb"));
 
         create_dir(&dir.join("__pycache__"));
-        create_file(dir.join("__pycache__/myfile.pyc"));
+        create_file(&dir.join("__pycache__/myfile.pyc"));
 
-        create_file(dir.join(".DS_Store"));
+        create_file(&dir.join(".DS_Store"));
 
         assert_eq!(emptydir(&dir), 1);
         assert_eq!(dir.exists(), false);
@@ -129,8 +129,8 @@ mod test_emptydir {
 
         create_dir(&dir);
 
-        create_file(dir.join(".DS_Store"));
-        create_file(dir.join("greeting.txt"));
+        create_file(&dir.join(".DS_Store"));
+        create_file(&dir.join("greeting.txt"));
 
         assert_eq!(emptydir(&dir), 0);
         assert_eq!(dir.exists(), true);
@@ -157,14 +157,14 @@ mod test_emptydir {
         create_dir(&subdir);
 
         create_dir(&subdir.join(".venv"));
-        create_file(subdir.join(".venv/bin/mypython.py"));
+        create_file(&subdir.join(".venv/bin/mypython.py"));
 
         create_dir(&subdir.join("__pycache__"));
-        create_file(subdir.join("__pycache__/myfile.pyc"));
+        create_file(&subdir.join("__pycache__/myfile.pyc"));
 
-        create_file(subdir.join(".DS_Store"));
+        create_file(&subdir.join(".DS_Store"));
 
-        create_file(dir.join("greeting.txt"));
+        create_file(&dir.join("greeting.txt"));
 
         assert_eq!(emptydir(&dir), 1);
         assert_eq!(dir.exists(), true);

--- a/src/emptydir.rs
+++ b/src/emptydir.rs
@@ -133,7 +133,8 @@ mod test_emptydir {
         create_file(&dir.join("greeting.txt"));
 
         assert_eq!(emptydir(&dir), 0);
-        assert_eq!(dir.exists(), true);
+        assert!(dir.exists());
+        assert!(dir.join("greeting.txt").exists());
     }
 
     #[test]
@@ -169,5 +170,6 @@ mod test_emptydir {
         assert_eq!(emptydir(&dir), 1);
         assert_eq!(dir.exists(), true);
         assert_eq!(subdir.exists(), false);
+        assert!(dir.join("greeting.txt").exists());
     }
 }

--- a/src/emptydir.rs
+++ b/src/emptydir.rs
@@ -27,6 +27,26 @@ pub fn emptydir(root: &Path) -> u32 {
         };
     }
 
+    // Now work our way upward through the parent directories, and
+    // delete any of those which are empty.
+    let mut current_parent = root.parent();
+
+    while let Some(parent) = current_parent {
+        if crate::can_be_deleted::can_be_deleted(parent) {
+            match fs::remove_dir_all(parent) {
+                Ok(_) => {
+                    println!("{}", parent.display());
+                    count_deleted += 1;
+                }
+                Err(_) => (),
+            };
+
+            current_parent = parent.parent();
+        } else {
+            break;
+        }
+    }
+
     count_deleted
 }
 


### PR DESCRIPTION
This is useful for work I'm doing to clean up a drive with heavily nested directories – I don't want to jump to the top of the directory tree myself, I want the tool to take a leaf and work out the whole tree.